### PR TITLE
Fixed generating of web.config and made web.config fail safe.

### DIFF
--- a/src/Oocx.ACME.Console/AcmeProcess.cs
+++ b/src/Oocx.ACME.Console/AcmeProcess.cs
@@ -59,7 +59,7 @@ namespace Oocx.ACME.Console
 
                 SaveCertificateWithPrivateKey(domain, keyPair, certificatePath);
                 
-                ConfigureServer(domain, certificatePath, keyPair, options.IISWebSite, options.IISBinidng);                
+                ConfigureServer(domain, certificatePath, keyPair, options.IISWebSite, options.IISBinding);                
             }
         }
 
@@ -156,8 +156,15 @@ namespace Oocx.ACME.Console
             }            
 
             System.Console.WriteLine(challenge.Instructions);
-            System.Console.WriteLine("Press ENTER to continue");
-            System.Console.ReadLine();
+            if (!options.AcceptInstructions)
+            {
+                System.Console.WriteLine("Press ENTER to continue");
+                System.Console.ReadLine();
+            }
+            else
+            {
+                System.Console.WriteLine("Automatically accepting instructions.");
+            }
             var challengeResult = await challenge.Complete();
             return "valid".Equals(challengeResult?.Status, StringComparison.OrdinalIgnoreCase);
         }

--- a/src/Oocx.ACME.Console/Options.cs
+++ b/src/Oocx.ACME.Console/Options.cs
@@ -11,7 +11,7 @@ namespace Oocx.ACME.Console
         [Option('s', "server", Default = "https://acme-v01.api.letsencrypt.org", HelpText = "Specifies the ACME server from which to request certificates.")]
         public string AcmeServer { get; set; }
         
-        [Value(0, HelpText = "The names of the domains for which you want to request a certificate.", Required = true, MetaName = "domains")]
+        [Option('d', "domain", HelpText = "The names of the domains for which you want to request a certificate.", Required = true)]
         public IEnumerable<string> Domains { get; set; }
 
         [Option('a', "acceptTermsOfService", HelpText = "Accept the terms of service of the ACME server")]
@@ -45,9 +45,12 @@ namespace Oocx.ACME.Console
         public string IISWebSite { get; set; }
 
         [Option('b', "iisBinding", HelpText = "The IIS binding that should be configured to use the new certificate. Syntax: ip:port:hostname, for example '*:443:www.example.com' (used with --serverConfigurationProvider iis). If you do not specifiy a binding, the provider will try to find a matching binding. It will create a binding if no matching binding exists.")]
-        public string IISBinidng { get; set; }
+        public string IISBinding { get; set; }
 
         [Option('m', "contact", HelpText = "The contact information for the registration request. Example: mailto:you@example.com")]
         public string Contact { get; set; }
-    }    
+
+        [Option('j', "acceptInstructions", HelpText = "Automatically accept the instructions.")]
+        public bool AcceptInstructions { get; set; }
+    }
 }

--- a/src/Oocx.ACME.Console/Program.cs
+++ b/src/Oocx.ACME.Console/Program.cs
@@ -6,6 +6,7 @@ using Autofac.Core;
 using static System.Console;
 
 using CommandLine;
+using CommandLine.Text;
 using Oocx.ACME.Client;
 using Oocx.ACME.Common;
 using static  Oocx.ACME.Common.Log;
@@ -16,8 +17,15 @@ namespace Oocx.ACME.Console
     {
         
         public void Main(string[] args)
-        {            
-            Parser.Default.ParseArguments<Options>(args)                
+        {
+            Parser parser = new Parser(config =>
+            {
+              config.EnableDashDash = true;
+              config.CaseSensitive = true;
+              config.IgnoreUnknownArguments = false;
+              config.HelpWriter = Out;
+            });
+            parser.ParseArguments<Options>(args)              
                 .WithNotParsed(ArgumentsError)
                 .WithParsed(Execute);
         }

--- a/src/Oocx.ACME.IIS/web.config
+++ b/src/Oocx.ACME.IIS/web.config
@@ -2,6 +2,7 @@
 <configuration>
   <system.webServer>
     <staticContent>
+      <remove fileExtension="." />
       <mimeMap fileExtension="." mimeType="application/jose+json" />
     </staticContent>
   </system.webServer>


### PR DESCRIPTION
I fixed the generation of the web.config, because it was using the wrong internal resourcename. And resulted in 0 bytes (Atleast for the CLR 4.6 version). And also I improved the contents of the web.config file so that it will work regardless of the contents of web.config's in directories above.
